### PR TITLE
ビルド環境整理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,9 @@
 Debug
 Release
 *.log
+Browse.VC.*db
+
+
+# test files
+test*.txt
+test*.log

--- a/cpp17_samples/cpp17_samples/lambda.cpp
+++ b/cpp17_samples/cpp17_samples/lambda.cpp
@@ -6,10 +6,9 @@
 #include <chrono>
 #include <iomanip>
 
-#pragma warning( push )
-#pragma warning( disable : 4996 ) 
 void lambda_sample()
 {
+    // 任意の変数値を表示する関数を定義する
     auto print_value = []( auto val, std::string prefix = "=== ", std::string suffix = " ===" ) noexcept {
         std::cout << prefix << val << suffix << std::endl;
     };
@@ -20,11 +19,10 @@ void lambda_sample()
     // 時間変換のサンプル
     using std::chrono::system_clock;
     // 現在時刻を取得
-    auto cur_time_time_point   = system_clock::now();
+    auto cur_time_point   = system_clock::now();
     // std::chrono::system_clock::time_point -> std::time_t
-    auto cur_time_time_t       = system_clock::to_time_t( cur_time_time_point );
+    auto cur_time_t       = system_clock::to_time_t( cur_time_point );
     // std::time_t -> const tm*
-    auto cur_time_const_tm_ptr = std::localtime( &cur_time_time_t );
-    print_value( std::put_time( cur_time_const_tm_ptr, "%c" ), "只今の時間は", "です" );
+    auto cur_const_tm_ptr = std::localtime( &cur_time_t );
+    print_value( std::put_time( cur_const_tm_ptr, "%c" ), "只今の時間は", "です" );
 }
-#pragma warning( pop )

--- a/cpp17_samples/cpp17_samples/main.cpp
+++ b/cpp17_samples/cpp17_samples/main.cpp
@@ -4,6 +4,7 @@
 #include "pch.h"
 
 #include <iostream>
+#include <string>
 
 void para_sample1( void );
 void map_sample( void );

--- a/cpp17_samples/cpp17_samples/pch.h
+++ b/cpp17_samples/cpp17_samples/pch.h
@@ -5,4 +5,10 @@
 
 #pragma once
 
+#pragma warning( push )
+#pragma warning( disable : 6001 6101 26434 26439 26444 26451 26495 26498 )
+
+#include <iostream>
 #include "winrt/Windows.Foundation.h"
+
+#pragma warning( pop )

--- a/cpp17_samples/cpp17_samples/smart_ptr.cpp
+++ b/cpp17_samples/cpp17_samples/smart_ptr.cpp
@@ -1,16 +1,15 @@
 ﻿#include "pch.h"
 
 #include <cstdio>
-#include <iostream>
 #include <memory>
 
 void smart_ptr_sample()
 {
-    // ファイルオープン失敗は考慮しない
     auto custom_deleter = []( auto f ) noexcept{
         std::cout << "file close" << std::endl;
         if( f ) fclose( f );
     };
+    // ファイルオープン失敗は考慮しない
     std::shared_ptr< FILE > pf( fopen( "test_custom_deleter.txt", "wt" ), custom_deleter );
     fputs( "&*   でファイルポインタを引く\n", &*pf );
     fputs( "get()でファイルポインタを引く\n", pf.get() );

--- a/cpp17_samples/cpp17_samples/util.cpp
+++ b/cpp17_samples/cpp17_samples/util.cpp
@@ -1,7 +1,5 @@
 ﻿#include "pch.h"
 
-#include <string>
-#include <iostream>
 #include <iomanip>
 
 struct UnknownAddrType{

--- a/cpp17_samples/cpp17_samples/util_types.cpp
+++ b/cpp17_samples/cpp17_samples/util_types.cpp
@@ -1,6 +1,5 @@
 ﻿#include "pch.h"
 
-#include <iostream>
 #include <vector>
 #include <map>
 
@@ -23,7 +22,7 @@ void map_sample2( void )
     std::cout << __func__ << std::endl;
 
     struct tbl_t{
-        int num;
+        int num = 0;
         std::string s;
     };
 


### PR DESCRIPTION
標準ライブラリ周りのwarningを除外する(コード解析を使えるようにする為)
C++標準string/iostreamをプリコンパイルドヘッダ入り