### PR TITLE
文字コード変更

### DIFF
--- a/cpp17_samples/cpp17_samples/cpp17_samples.vcxproj
+++ b/cpp17_samples/cpp17_samples/cpp17_samples.vcxproj
@@ -33,7 +33,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/cpp17_samples/cpp17_samples/lang_feature.cpp
+++ b/cpp17_samples/cpp17_samples/lang_feature.cpp
@@ -8,7 +8,7 @@ template < typename ... Types >
 auto strcat_plus( Types ... args )
 {
     auto to_str = []( auto p ){
-        return std::string( p );
+        return std::wstring( p );
     };
     return ( ... + to_str( args ) );
 }
@@ -20,19 +20,19 @@ void lambda_capture_sample()
     // キャプチャ環境で変更する場合はmutable指定が必要
     auto print_increased_i = [ i ]() mutable {
         i++; // mutable指定しないとコンパイルエラー
-        std::cout << "[capture]   i is " << i << std::endl;
+        std::wcout << L"[capture]   i is " << i << std::endl;
     };
     print_increased_i(); // i is 1
 
     // コピーキャプチャは呼び元の変数に影響を及ぼさない
-    std::cout << "[outer env] i is " << i << std::endl; // i is 0
+    std::wcout << L"[outer env] i is " << i << std::endl; // i is 0
 
     // 参照キャプチャーはiへの参照を扱うので、呼び元のiに対して変更が行える
     auto modify_i = [ & ](){
         i = 12345678;
     };
     modify_i();
-    std::cout << std::setbase( 10 ) << "[modified]  i is " << i << std::endl; // i is 12345678
+    std::wcout << std::setbase( 10 ) << L"[modified]  i is " << i << std::endl; // i is 12345678
 
     // 複数変数のコピーキャプチャ
     int x = 100;
@@ -64,6 +64,6 @@ void lambda_capture_sample()
 void fold_sample()
 {
     // 任意個数の文字列を結合するstrcat()
-    std::cout << strcat_plus( "one", "two", "three" ) << std::endl;
-    std::cout << strcat_plus( "Hello", "world.") << std::endl;
+    std::wcout << strcat_plus( L"one", L"two", L"three" ) << std::endl;
+    std::wcout << strcat_plus( L"Hello", L"world.") << std::endl;
 }

--- a/cpp17_samples/cpp17_samples/main.cpp
+++ b/cpp17_samples/cpp17_samples/main.cpp
@@ -10,42 +10,42 @@
 int main()
 {
 #ifdef PARA_SAMPLE
-    std::cout << "\n\n\n=== Paralells sample ===" << std::endl;
+    std::wcout << L"\n\n\n=== Paralells sample ===" << std::endl;
     para_sample1();
     para_sample2();
 #endif
 
 #ifdef MAP_SAMPLE
-    std::cout << "\n\n\n=== map sample ===" << std::endl;
+    std::wcout << L"\n\n\n=== map sample ===" << std::endl;
     map_sample();
     map_sample2();
 #endif
 
 #ifdef TUPLE_SAMPLE
-    std::cout << "\n\n\n=== tuple sample ===" << std::endl;
+    std::wcout << L"\n\n\n=== tuple sample ===" << std::endl;
     tuple_sample();
 #endif
 
 #ifdef LAMBDA_SAMPLE
-    std::cout << "\n\n\n=== lambda sample ===" << std::endl;
+    std::wcout << L"\n\n\n=== lambda sample ===" << std::endl;
     lambda_sample();
 #endif
 
 #ifdef UTIL_SAMPLE
-    std::cout << "\n\n\n=== addressof sample ===" << std::endl;
+    std::wcout << L"\n\n\n=== addressof sample ===" << std::endl;
     util_sample();
 
-    std::cout << "\n\n\n=== fold expression sample ===" << std::endl;
+    std::wcout << L"\n\n\n=== fold expression sample ===" << std::endl;
     fold_sample();
 #endif
 
 #ifdef SMART_PTR_SAMPLE
-    std::cout << "\n\n\n=== custom deleter sample ===" << std::endl;
+    std::wcout << "\n\n\n=== custom deleter sample ===" << std::endl;
     smart_ptr_sample();
 #endif
 
 #ifdef LAMBDA_CAP_SAMPLE
-    std::cout << "\n\n\n=== lambda capture sample ===" << std::endl;
+    std::wcout << "\n\n\n=== lambda capture sample ===" << std::endl;
     lambda_capture_sample();
 #endif
 }

--- a/cpp17_samples/cpp17_samples/parallel.cpp
+++ b/cpp17_samples/cpp17_samples/parallel.cpp
@@ -17,7 +17,7 @@ bool check_container_contents( container_t const & container, predicate pred )
 
 void para_sample1( void )
 {
-    std::cout << __func__ << std::endl;
+    std::wcout << __func__ << std::endl;
 
     std::vector< int > vec;
     for( int i = 0; i < 100; i++ )
@@ -27,27 +27,27 @@ void para_sample1( void )
     auto is_even_num = []( auto x ) noexcept { return ( ( x % 2 ) == 0 ); };
     auto is_odd_num = []( auto x ) noexcept { return ( ( x % 2 ) != 0 ); };
     auto bool2str = []( bool b ) noexcept {
-        // HStringからstd::string変換を試す
+        // HStringからstd::wstring変換を試す
         winrt::hstring hs = b ? L"true" : L"false";
         return winrt::to_string( hs );
     };
 
-    std::cout << "コンテナ要素チェック" << std::endl;
-    printf( u8"less_than100 -> %s\n", bool2str( check_container_contents( vec, less_than100 ) ).c_str() );
-    printf( u8"is_even_num  -> %s\n", bool2str( check_container_contents( vec, is_even_num ) ).c_str() );
-    printf( u8"is_odd_num   -> %s\n", bool2str( check_container_contents( vec, is_odd_num ) ).c_str() );
+    std::wcout << "コンテナ要素チェック" << std::endl;
+    printf( "less_than100 -> %s\n", bool2str( check_container_contents( vec, less_than100 ) ).c_str() );
+    printf( "is_even_num  -> %s\n", bool2str( check_container_contents( vec, is_even_num ) ).c_str() );
+    printf( "is_odd_num   -> %s\n", bool2str( check_container_contents( vec, is_odd_num ) ).c_str() );
 
     // 詰め直す
-    std::cout << "-----------------------------------------" << std::endl;
-    std::cout << "コンテナ詰め直し" << std::endl;
-    std::cout << "-----------------------------------------" << std::endl;
+    std::wcout << "-----------------------------------------" << std::endl;
+    std::wcout << "コンテナ詰め直し" << std::endl;
+    std::wcout << "-----------------------------------------" << std::endl;
     vec.clear();
     for( int i = 0; i < 100; i += 2 )
         vec.push_back( i );
 
-    printf( u8"less_than100 -> %s\n", bool2str( check_container_contents( vec, less_than100 ) ).c_str() );
-    printf( u8"is_even_num  -> %s\n", bool2str( check_container_contents( vec, is_even_num ) ).c_str() );
-    printf( u8"is_odd_num   -> %s\n", bool2str( check_container_contents( vec, is_odd_num ) ).c_str() );
+    printf( "less_than100 -> %s\n", bool2str( check_container_contents( vec, less_than100 ) ).c_str() );
+    printf( "is_even_num  -> %s\n", bool2str( check_container_contents( vec, is_even_num ) ).c_str() );
+    printf( "is_odd_num   -> %s\n", bool2str( check_container_contents( vec, is_odd_num ) ).c_str() );
 }
 
 
@@ -58,10 +58,10 @@ void para_sample2()
         vec.push_back( std::to_string( i ) );
 
     auto print_func = [ line_num = 0 ]( auto s ) mutable{
-        // C++の書式文字列の作成サンプル
-        std::stringstream format_string;
-        format_string << std::setw( 4 ) << std::setfill( '0' ) << line_num++ << ": " << s;
-        std::cout << format_string.str() << std::endl;
+        char buf[ 256 ];
+        sprintf_s( buf, sizeof( buf ), "%04d: %s", line_num++, s.c_str() );
+        std::string ss( buf );
+        std::cout << ss << std::endl;
     };
 
     // 簡単に並列化出来るとはいえ、順序を守る必要があるケースでは当然バグる

--- a/cpp17_samples/cpp17_samples/smart_ptr.cpp
+++ b/cpp17_samples/cpp17_samples/smart_ptr.cpp
@@ -6,7 +6,7 @@
 void smart_ptr_sample()
 {
     auto custom_deleter = []( auto f ) noexcept{
-        std::cout << "file close" << std::endl;
+        std::wcout << "file close" << std::endl;
         if( f ) fclose( f );
     };
     // ファイルオープン失敗は考慮しない

--- a/cpp17_samples/cpp17_samples/util.cpp
+++ b/cpp17_samples/cpp17_samples/util.cpp
@@ -7,15 +7,15 @@ struct UnknownAddrType{
 };
 
 template < typename T >
-void print_addr( std::string prefix,T t )
+void print_addr( std::wstring prefix,T t )
 {
-    std::cout << std::setbase( 16 ) << prefix << ( &t ) << std::endl;
+    std::wcout << std::setbase( 16 ) << prefix << ( &t ) << std::endl;
 }
 
 template < typename T >
-void print_addr2( std::string prefix, T t )
+void print_addr2( std::wstring prefix, T t )
 {
-    std::cout << std::setbase( 16 ) << prefix << std::addressof( t ) << std::endl;
+    std::wcout << std::setbase( 16 ) << prefix << std::addressof( t ) << std::endl;
 }
 
 void util_sample()
@@ -23,10 +23,10 @@ void util_sample()
     int hoge = 0;
     UnknownAddrType hoge2;
 
-    print_addr( "int             hoge  addr is : ", hoge );
-    print_addr( "UnknownAddrType hoge2 addr is : ", hoge2 );
+    print_addr( L"int             hoge  addr is : ", hoge );
+    print_addr( L"UnknownAddrType hoge2 addr is : ", hoge2 );
 
-    print_addr2( "int             hoge  addr is : ", hoge );
-    print_addr2( "UnknownAddrType hoge2 addr is : ", hoge2 );
+    print_addr2( L"int             hoge  addr is : ", hoge );
+    print_addr2( L"UnknownAddrType hoge2 addr is : ", hoge2 );
 }
 

--- a/cpp17_samples/cpp17_samples/util_types.cpp
+++ b/cpp17_samples/cpp17_samples/util_types.cpp
@@ -5,7 +5,7 @@
 
 void map_sample( void )
 {
-    std::cout << __func__ << std::endl;
+    std::wcout << __func__ << std::endl;
 
     std::map< int, std::string > tbl
     {
@@ -19,7 +19,7 @@ void map_sample( void )
 
 void map_sample2( void )
 {
-    std::cout << __func__ << std::endl;
+    std::wcout << __func__ << std::endl;
 
     struct tbl_t{
         int num = 0;
@@ -43,7 +43,7 @@ struct elem3container{
 
 void tuple_sample( void )
 {
-    std::cout << __func__ << std::endl;
+    std::wcout << __func__ << std::endl;
 
     std::vector< elem3container< int, int, int > > vec;
     vec.push_back( {   1, 0b0000'0001, 0x01 } );


### PR DESCRIPTION
IOマニピュレータが使いにくいので、素直にsprintf()で代用
boost::formatは非標準の為、検討対象外としました