### PR TITLE
boost::logサンプル追加。VSのバージョン更新

### DIFF
--- a/cpp_samples/cpp_samples.sln
+++ b/cpp_samples/cpp_samples.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27703.2047
+VisualStudioVersion = 15.0.28010.2016
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "cpp_samples", "cpp_samples\cpp_samples.vcxproj", "{DCA3EE17-0257-4424-9019-94BD205CB919}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "cpp_samples", "cpp_samples\cpp_samples.vcxproj", "{DDB47883-6C36-42C0-AC19-2E525CBAE007}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,19 +13,19 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{DCA3EE17-0257-4424-9019-94BD205CB919}.Debug|x64.ActiveCfg = Debug|x64
-		{DCA3EE17-0257-4424-9019-94BD205CB919}.Debug|x64.Build.0 = Debug|x64
-		{DCA3EE17-0257-4424-9019-94BD205CB919}.Debug|x86.ActiveCfg = Debug|Win32
-		{DCA3EE17-0257-4424-9019-94BD205CB919}.Debug|x86.Build.0 = Debug|Win32
-		{DCA3EE17-0257-4424-9019-94BD205CB919}.Release|x64.ActiveCfg = Release|x64
-		{DCA3EE17-0257-4424-9019-94BD205CB919}.Release|x64.Build.0 = Release|x64
-		{DCA3EE17-0257-4424-9019-94BD205CB919}.Release|x86.ActiveCfg = Release|Win32
-		{DCA3EE17-0257-4424-9019-94BD205CB919}.Release|x86.Build.0 = Release|Win32
+		{DDB47883-6C36-42C0-AC19-2E525CBAE007}.Debug|x64.ActiveCfg = Debug|x64
+		{DDB47883-6C36-42C0-AC19-2E525CBAE007}.Debug|x64.Build.0 = Debug|x64
+		{DDB47883-6C36-42C0-AC19-2E525CBAE007}.Debug|x86.ActiveCfg = Debug|Win32
+		{DDB47883-6C36-42C0-AC19-2E525CBAE007}.Debug|x86.Build.0 = Debug|Win32
+		{DDB47883-6C36-42C0-AC19-2E525CBAE007}.Release|x64.ActiveCfg = Release|x64
+		{DDB47883-6C36-42C0-AC19-2E525CBAE007}.Release|x64.Build.0 = Release|x64
+		{DDB47883-6C36-42C0-AC19-2E525CBAE007}.Release|x86.ActiveCfg = Release|Win32
+		{DDB47883-6C36-42C0-AC19-2E525CBAE007}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {85430667-FDBE-4C74-81B8-C7F7766EA42B}
+		SolutionGuid = {30517901-C224-4C68-B0EA-3E8A8DD825B0}
 	EndGlobalSection
 EndGlobal

--- a/cpp_samples/cpp_samples/boost/logging.cpp
+++ b/cpp_samples/cpp_samples/boost/logging.cpp
@@ -1,0 +1,25 @@
+﻿#include "pch.h"
+
+#include <boost/log/trivial.hpp>
+#include <boost/log/core.hpp>
+#include <boost/log/utility/setup/file.hpp>
+#include <boost/log/expressions.hpp>
+
+void boost_logging_sample()
+{
+    // サンプルコードはboost.orgのものを拝借
+    using namespace boost::log;
+
+    // ロギングファイル設定
+    add_file_log( R"*(./test_dir/boost_log.txt)*" );
+
+    // ロギングレベル(warning)以上のものをロギング対象に設定
+    core::get()->set_filter( trivial::severity >= trivial::warning );
+
+    BOOST_LOG_TRIVIAL( trace ) << "A trace severity message";
+    BOOST_LOG_TRIVIAL( debug ) << "A debug severity message";
+    BOOST_LOG_TRIVIAL( info ) << "An informational severity message";
+    BOOST_LOG_TRIVIAL( warning ) << "A warning severity message";
+    BOOST_LOG_TRIVIAL( error ) << "An error severity message";
+    BOOST_LOG_TRIVIAL( fatal ) << "A fatal severity message";
+}

--- a/cpp_samples/cpp_samples/cpp_samples.vcxproj
+++ b/cpp_samples/cpp_samples/cpp_samples.vcxproj
@@ -5,7 +5,7 @@
     <RequiredBundles>$(RequiredBundles);Microsoft.Windows.CppWinRT</RequiredBundles>
     <MinimalCoreWin>true</MinimalCoreWin>
     <VCProjectVersion>15.0</VCProjectVersion>
-    <ProjectGuid>{dca3ee17-0257-4424-9019-94bd205cb919}</ProjectGuid>
+    <ProjectGuid>{ddb47883-6c36-42c0-ac19-2e525cbae007}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>cpp_samples</RootNamespace>
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.17134.0</WindowsTargetPlatformVersion>
@@ -60,13 +60,13 @@
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <PreprocessorDefinitions>_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level4</WarningLevel>
-      <AdditionalOptions>%(AdditionalOptions) /permissive- /bigobj</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions) /permissive- /bigobj /Zc:twoPhase-</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(ProjectDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -76,7 +76,8 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)'=='Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(ProjectDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
@@ -84,8 +85,9 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(ProjectDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(ProjectDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -99,6 +101,12 @@
     <ClInclude Include="select_sample.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="boost\logging.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="filesystem\filesystem.cpp" />
     <ClCompile Include="functional\lambda.cpp" />
     <ClCompile Include="lang_feature\lang_feature.cpp" />

--- a/cpp_samples/cpp_samples/cpp_samples.vcxproj.filters
+++ b/cpp_samples/cpp_samples/cpp_samples.vcxproj.filters
@@ -13,32 +13,29 @@
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
-    <Filter Include="Source Files\samples">
-      <UniqueIdentifier>{b97e37cd-1163-43d9-9c62-668935e26fce}</UniqueIdentifier>
+    <Filter Include="Source Files\parallels">
+      <UniqueIdentifier>{7bbb3535-b8b0-4340-b9bd-97eaf02e3ffd}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Source Files\samples\parallels">
-      <UniqueIdentifier>{3811e300-5d23-4e38-9d82-9192978b638d}</UniqueIdentifier>
+    <Filter Include="Source Files\fs">
+      <UniqueIdentifier>{716aac9e-2942-4877-b9e0-13fcc543fc4c}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Source Files\samples\fs">
-      <UniqueIdentifier>{2f0e2760-40d9-4fdd-aeed-5a8978619244}</UniqueIdentifier>
+    <Filter Include="Source Files\util">
+      <UniqueIdentifier>{57fe8031-243b-4a8a-a59a-471acb64c492}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Source Files\samples\util">
-      <UniqueIdentifier>{4562d7c6-1b50-499f-85e3-8b3ce7baa811}</UniqueIdentifier>
+    <Filter Include="Source Files\memory">
+      <UniqueIdentifier>{24d48a18-b71b-4672-8e9d-e6c84d9857a2}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Source Files\samples\memory">
-      <UniqueIdentifier>{048dc27b-293e-4e1e-9c75-78d439052944}</UniqueIdentifier>
+    <Filter Include="Source Files\lang_feature">
+      <UniqueIdentifier>{c3d17aab-046f-4e4f-a69a-ba08179ec583}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Source Files\samples\lang_feature">
-      <UniqueIdentifier>{3511f572-665a-4d8d-a3a7-0eee04059398}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\samples\functional">
-      <UniqueIdentifier>{a099ffae-84d1-4a5f-b395-b565454911a3}</UniqueIdentifier>
+    <Filter Include="Source Files\functional">
+      <UniqueIdentifier>{0b7796ad-12c6-43bd-8c90-a7b66894b628}</UniqueIdentifier>
     </Filter>
     <Filter Include="Source Files\boost_samples">
-      <UniqueIdentifier>{27ecaee8-6665-44e9-a86c-1f9d6b003a5e}</UniqueIdentifier>
+      <UniqueIdentifier>{f43330f7-33ba-4cb1-b809-e8a6de7665da}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Source Files\samples\winrt">
-      <UniqueIdentifier>{27961745-af30-48a6-9bf3-0b1bd9de3cb3}</UniqueIdentifier>
+    <Filter Include="Source Files\winrt">
+      <UniqueIdentifier>{c621d7ad-69b7-42b6-8687-cbcfb6bdea92}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -57,31 +54,34 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="filesystem\filesystem.cpp">
-      <Filter>Source Files\samples\fs</Filter>
+      <Filter>Source Files\fs</Filter>
     </ClCompile>
     <ClCompile Include="memory\smart_ptr.cpp">
-      <Filter>Source Files\samples\memory</Filter>
+      <Filter>Source Files\memory</Filter>
     </ClCompile>
     <ClCompile Include="lang_feature\lang_feature.cpp">
-      <Filter>Source Files\samples\lang_feature</Filter>
+      <Filter>Source Files\lang_feature</Filter>
     </ClCompile>
     <ClCompile Include="functional\lambda.cpp">
-      <Filter>Source Files\samples\functional</Filter>
+      <Filter>Source Files\functional</Filter>
     </ClCompile>
-    <ClCompile Include="util\util.cpp">
-      <Filter>Source Files\samples\util</Filter>
-    </ClCompile>
-    <ClCompile Include="util\util_types.cpp">
-      <Filter>Source Files\samples\util</Filter>
-    </ClCompile>
-    <ClCompile Include="parallels\parallel.cpp">
-      <Filter>Source Files\samples\parallels</Filter>
+    <ClCompile Include="boost\logging.cpp">
+      <Filter>Source Files\boost_samples</Filter>
     </ClCompile>
     <ClCompile Include="util\datetime.cpp">
-      <Filter>Source Files\samples\util</Filter>
+      <Filter>Source Files\util</Filter>
+    </ClCompile>
+    <ClCompile Include="util\util.cpp">
+      <Filter>Source Files\util</Filter>
+    </ClCompile>
+    <ClCompile Include="util\util_types.cpp">
+      <Filter>Source Files\util</Filter>
+    </ClCompile>
+    <ClCompile Include="parallels\parallel.cpp">
+      <Filter>Source Files\parallels</Filter>
     </ClCompile>
     <ClCompile Include="winrt\winrt.cpp">
-      <Filter>Source Files\samples\winrt</Filter>
+      <Filter>Source Files\winrt</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/cpp_samples/cpp_samples/functional/lambda.cpp
+++ b/cpp_samples/cpp_samples/functional/lambda.cpp
@@ -1,9 +1,5 @@
 ﻿#include "pch.h"
 
-#include <ctime>
-#include <chrono>
-#include <iomanip>
-
 void lambda_sample( void )
 {
     // 任意の変数値を表示する関数を定義する

--- a/cpp_samples/cpp_samples/main.cpp
+++ b/cpp_samples/cpp_samples/main.cpp
@@ -55,10 +55,19 @@ int main()
 #endif
 
 #ifdef FILESYTEM_SAMPLE
+    std::wcout << L"\n\n\n=== FileSystem sample ===" << std::endl;
     filesystem_sample();
 #endif
 
+#ifdef BOOST_SAMPLE
+#ifdef BOOST_LOG_SAMPLE
+    std::wcout << L"\n\n\n=== [Boost] logging sample ===" << std::endl;
+    boost_logging_sample();
+#endif
+#endif
+
 #ifdef WIN_RT_SAMPLE
+    std::wcout << L"\n\n\n=== [WinRT] sample ===" << std::endl;
     winrt_sample();
 #endif
 }

--- a/cpp_samples/cpp_samples/select_sample.h
+++ b/cpp_samples/cpp_samples/select_sample.h
@@ -9,6 +9,9 @@
 #define SMART_PTR_SAMPLE
 #define LAMBDA_CAP_SAMPLE
 #define FILESYTEM_SAMPLE
+
+#define BOOST_SAMPLE
+#define BOOST_LOG_SAMPLE
 #define WIN_RT_SAMPLE
 
 void para_sample1( void );
@@ -23,4 +26,5 @@ void smart_ptr_sample( void );
 void fold_sample( void );
 void lambda_capture_sample( void );
 void filesystem_sample( void );
+void boost_logging_sample( void );
 void winrt_sample( void );


### PR DESCRIPTION
boostをvcpkg(https://docs.microsoft.com/ja-jp/cpp/vcpkg)で導入するも、x64を見つけられなかったのでx86版を使用
Windows SDK 17134導入後、WinRTのプロジェクトテンプレートがビルドエラーとなる事が発覚。既知の問題でコマンドラインオプション"/Zc:twoPhase- "を追加(2フェーズの名前検索を無効化する機能との事)
<https://stackoverflow.com/questions/51066729/c-winrt-part-of-windows-sdk-17134-is-not-compatible-with-visual-studio-15-8-p>