### PR TITLE
(boost)イテレータ/ロックフリーコンテナサンプル追加

### DIFF
--- a/cpp_samples/cpp_samples/boost/create_iter.cpp
+++ b/cpp_samples/cpp_samples/boost/create_iter.cpp
@@ -1,0 +1,44 @@
+﻿#include "pch.h"
+
+#include <ostream>
+#include <algorithm>
+#include <boost/iterator_adaptors.hpp>
+
+class my_container_t{
+    int arr_[ 128 ];
+    int size_;
+
+public:
+    struct iterator : public boost::iterator_adaptor< iterator, int* >
+    {
+        iterator( int *p )
+            : iterator::iterator_adaptor_( p )
+        {}
+    };
+
+    my_container_t()
+        : size_( sizeof( arr_ ) )
+    {
+        for( int i = 0; i < size_ - 1; ++i )
+            arr_[ i ] = i;
+    }
+
+    iterator begin()
+    {
+        return iterator( arr_ );
+    }
+
+    iterator end()
+    {
+        return iterator( arr_ + size_ );
+    }
+};
+
+void boost_create_iter_sample()
+{
+    my_container_t c;
+    auto print_fn = []( auto x ){
+        std::cout << x << std::endl;
+    };
+    std::for_each( c.begin(), c.end(), print_fn );
+}

--- a/cpp_samples/cpp_samples/boost/lock_free_container.cpp
+++ b/cpp_samples/cpp_samples/boost/lock_free_container.cpp
@@ -1,0 +1,37 @@
+﻿#include "pch.h"
+
+#include <thread>
+#include <boost/lockfree/queue.hpp>
+#include <boost/lockfree/stack.hpp>
+
+const int CONTAINER_SIZE = 0x100;
+
+template < typename T >
+void lock_free_container_test( void )
+{
+    T container( CONTAINER_SIZE );
+    std::thread push_fn( [ & ]() {
+        for( int i = 0; i < CONTAINER_SIZE; ++i )
+            while( !container.push( i ) ); // コンテナへデータを追加
+    } );
+    std::thread pop_fn( [ & ]() {
+        for( int count = 0; count < CONTAINER_SIZE; count++ ) {
+            int x = 0;
+            if( container.pop( x ) ) // コンテナからデータを取り出し
+                printf( "%3d ", x );
+        }
+    } ); 
+    push_fn.join();
+    pop_fn.join();
+}
+
+void boost_lock_free_container_sample( void )
+{
+    std::cout << "--- lock free queue test ---" << std::endl;
+    lock_free_container_test< boost::lockfree::queue< int > >();
+    std::cout << std::endl;
+
+    std::cout << "--- lock free stack test ---" << std::endl;
+    lock_free_container_test< boost::lockfree::stack< int > >();
+    std::cout << std::endl;
+}

--- a/cpp_samples/cpp_samples/cpp_samples.vcxproj
+++ b/cpp_samples/cpp_samples/cpp_samples.vcxproj
@@ -101,6 +101,8 @@
     <ClInclude Include="select_sample.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="boost\create_iter.cpp" />
+    <ClCompile Include="boost\lock_free_container.cpp" />
     <ClCompile Include="boost\logging.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>

--- a/cpp_samples/cpp_samples/cpp_samples.vcxproj.filters
+++ b/cpp_samples/cpp_samples/cpp_samples.vcxproj.filters
@@ -83,6 +83,12 @@
     <ClCompile Include="winrt\winrt.cpp">
       <Filter>Source Files\winrt</Filter>
     </ClCompile>
+    <ClCompile Include="boost\create_iter.cpp">
+      <Filter>Source Files\boost_samples</Filter>
+    </ClCompile>
+    <ClCompile Include="boost\lock_free_container.cpp">
+      <Filter>Source Files\boost_samples</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Text Include="readme.txt" />

--- a/cpp_samples/cpp_samples/main.cpp
+++ b/cpp_samples/cpp_samples/main.cpp
@@ -64,6 +64,16 @@ int main()
     std::wcout << L"\n\n\n=== [Boost] logging sample ===" << std::endl;
     boost_logging_sample();
 #endif
+
+#ifdef BOOST_CREATE_ITER_SAMPLE
+    std::wcout << L"\n\n\n=== [Boost] create iterator sample ===" << std::endl;
+    boost_create_iter_sample();
+#endif
+
+#ifdef BOOST_LOCK_FREE_CONTAINER_SAMPLE
+    std::wcout << L"\n\n\n=== [Boost] lock free container sample ===" << std::endl;
+    boost_lock_free_container_sample();
+#endif
 #endif
 
 #ifdef WIN_RT_SAMPLE

--- a/cpp_samples/cpp_samples/select_sample.h
+++ b/cpp_samples/cpp_samples/select_sample.h
@@ -12,19 +12,30 @@
 
 #define BOOST_SAMPLE
 #define BOOST_LOG_SAMPLE
+#define BOOST_CREATE_ITER_SAMPLE
+#define BOOST_LOCK_FREE_CONTAINER_SAMPLE
+
 #define WIN_RT_SAMPLE
 
 void para_sample1( void );
 void para_sample2( void );
+
 void map_sample( void );
 void map_sample2( void );
+
 void tuple_sample( void );
+
 void lambda_sample( void );
+void lambda_capture_sample( void );
+
 void time_sample( void );
 void util_sample( void );
 void smart_ptr_sample( void );
 void fold_sample( void );
-void lambda_capture_sample( void );
 void filesystem_sample( void );
+
 void boost_logging_sample( void );
+void boost_create_iter_sample( void );
+void boost_lock_free_container_sample( void );
+
 void winrt_sample( void );


### PR DESCRIPTION
ロックフリースタックの挙動が変(終端エントリ付近でデータが壊れている)